### PR TITLE
Decrypt BOSH Release

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,41 +1,41 @@
 ---
 docker/aufs-tools_20120411-3_amd64.deb:
-  object_id: 0866debb-d731-4c1c-b442-3294247506e8
+  object_id: c56fabd2-fc6c-4467-911b-5bc0a267f402
   sha: 2dfc1fe386cd3f05ac7e0b4ebcf3ebc8a7f3b04d
   size: 91762
-ruby/yaml-0.1.6.tar.gz:
-  object_id: f83bdc13-d038-4cda-abe3-b477d3fabbba
-  sha: f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d
-  size: 503012
 docker/autoconf-2.69.tar.gz:
-  object_id: 8e2d0f8a-fb08-4dd6-99a7-0f5fada93c82
+  object_id: e5862ef5-142e-486b-b17f-7dd72e7f4a15
   sha: 562471cbcb0dd0fa42a76665acf0dbb68479b78a
   size: 1927468
 docker/bridge-utils-1.5.tar.gz:
-  object_id: 7ec3ecd0-b4fa-425c-bf53-acd6200e357e
+  object_id: 3253d1aa-0846-43b6-a22e-48f7a7905a47
   sha: 1f71b6f22f5d2b6d21e146f4ac20820ad42e58ee
   size: 33472
 docker/docker-1.9.0:
-  object_id: 5fb14fb3-1370-4a15-80b2-a71eb56dbefd
+  object_id: 95bb02cd-1df9-4c75-80d0-441fcc0c508d
   sha: bf0d17521cc01324029fa9679f66d0066e09b8c6
   size: 30186828
+docker/docker-1.9.1:
+  object_id: 0ec63964-9bbb-4276-8048-cfa6b58f1ed9
+  sha: 424920b09c24d7c7876cc35d8aabd2aa52b8e39e
+  size: 30222575
 golang/go1.5.1.linux-amd64.tar.gz:
-  object_id: 197e9db5-5127-424e-ad72-602e2aa629fd
+  object_id: 3c26a347-ae52-4ccb-b0e3-f22e3e863c7c
   sha: 46eecd290d8803887dec718c691cc243f2175fe0
   size: 77875767
 ruby/bundler-1.10.6.gem:
-  object_id: dd1cc4d6-a96f-49b5-8be5-2c5d527156d8
+  object_id: fe11c6d1-bbfe-4865-8687-5010b45fb399
   sha: 55a37fccd1c0cb5542d468e35d3be46dd0667f73
   size: 251392
 ruby/ruby-2.2.3.tar.gz:
-  object_id: 2d37e431-c3a2-44d4-b081-22174f586523
+  object_id: e4e21c91-1176-4455-b367-097f7bdef1d0
   sha: 0d9e158534cb31e72740138b8f697b57b448e5c3
   size: 16626772
 ruby/rubygems-2.5.0.tgz:
-  object_id: 99378b46-70a9-49e9-9a49-b63ebd35026a
+  object_id: 218484d6-81a4-40e1-b7ca-e720ce3ba3a8
   sha: 03613d7013b61ecabef2424221438a692e53bbfc
   size: 467978
-docker/docker-1.9.1:
-  object_id: f4c49781-bd36-453e-9e12-20d3279af261
-  sha: 424920b09c24d7c7876cc35d8aabd2aa52b8e39e
-  size: 30222575
+ruby/yaml-0.1.6.tar.gz:
+  object_id: c6eb17c4-f0e5-41fe-8114-8a3cb67f6327
+  sha: f3d404e11bec3c4efcddfd14c42d46f1aabe0b5d
+  size: 503012

--- a/config/final.yml
+++ b/config/final.yml
@@ -4,6 +4,3 @@ blobstore:
   provider: s3
   options:
     bucket_name: docker-boshrelease
-    access_key_id: AKIAJPWUHOHV42IMTNQQ
-    secret_access_key: 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
-    encryption_key: cloudfoundry-community


### PR DESCRIPTION
Newest bosh_cli doesn't support blob encryption anymore. To make this boshrelease compatible I have re-uploaded the blobs unencrypted.
closes #52