### PR TITLE
Update cf containers broker

### DIFF
--- a/jobs/cf-containers-broker/spec
+++ b/jobs/cf-containers-broker/spec
@@ -53,6 +53,9 @@ properties:
   broker.fetch_images:
     description: "Fetch new/updated container images on restart"
     default: true
+  broker.update_containers:
+    description: "Restart all containers with latest configuration/image on restart"
+    default: true
   broker.services:
     description: "Services and plans offered by the broker"
 

--- a/jobs/cf-containers-broker/templates/bin/cf-containers-broker_ctl
+++ b/jobs/cf-containers-broker/templates/bin/cf-containers-broker_ctl
@@ -25,6 +25,13 @@ case $1 in
           2>>${CF_CONTAINERS_BROKER_LOG_DIR}/fetch_containers_images.stderr.log
     fi
 
+    # Update Containers
+    if [[ "${CF_CONTAINERS_UPDATE_CONTAINERS}X" != "X" ]]; then
+      bundle exec update_all_containers \
+          >>${CF_CONTAINERS_BROKER_LOG_DIR}/update_containers.stdout.log \
+          2>>${CF_CONTAINERS_BROKER_LOG_DIR}/update_containers.stderr.log
+    fi
+
     # We remove the PID file (own process) to prevent a collision with Unicorn
     rm -fr ${CF_CONTAINERS_BROKER_PID_FILE}
 

--- a/jobs/cf-containers-broker/templates/bin/job_properties.sh.erb
+++ b/jobs/cf-containers-broker/templates/bin/job_properties.sh.erb
@@ -21,6 +21,9 @@ export CF_CONTAINERS_BROKER_TMP_DIR=$TMP_DIR
 
 # Fetch new/updated container images on restart
 export CF_CONTAINERS_FETCH_IMAGES=<%= p('broker.fetch_images') ? 'true' : '' %>
+#
+# Restart containers with latest image/config on restart
+export CF_CONTAINERS_UPDATE_CONTAINERS=<%= p('broker.update_containers') ? 'true' : '' %>
 
 # CF-Containers-Broker Gemfile
 export BUNDLE_GEMFILE=/var/vcap/packages/cf-containers-broker/Gemfile


### PR DESCRIPTION
Enable automatic restart of containers with newest image/configuration when job cf-containers-broker is restarted.
See the [cf-containers-broker README](https://github.com/cloudfoundry-community/cf-containers-broker#updating-containers) for details.