### PR TITLE
Upgrades docker to version 1.11.0

### DIFF
--- a/jobs/docker/templates/bin/docker_ctl
+++ b/jobs/docker/templates/bin/docker_ctl
@@ -5,6 +5,7 @@ set -e # exit immediately if a simple command exits with a non-zero status
 # Setup common env vars and folders
 source /var/vcap/packages/bosh-helpers/ctl_setup.sh 'docker'
 export DOCKER_PID_FILE=${DOCKER_PID_DIR}/docker.pid
+export PATH="/var/vcap/packages/docker/bin:$PATH"
 
 case $1 in
 
@@ -38,7 +39,7 @@ case $1 in
     fi
 
     # Start Docker daemon
-    exec /var/vcap/packages/docker/bin/docker daemon \
+    exec docker daemon \
         ${DOCKER_API_CORS_HEADER} \
         ${DOCKER_BRIDGE:-} \
         ${DOCKER_DEBUG} \

--- a/packages/docker/packaging
+++ b/packages/docker/packaging
@@ -8,7 +8,7 @@ CPUS=`grep -c ^processor /proc/cpuinfo`
 AUFS_TOOLS_VERSION=`ls -r docker/aufs-tools_*.deb | sed 's/docker\/aufs-tools_\(.*\).deb/\1/' | head -1`
 AUTOCONF_VERSION=`ls -r docker/autoconf-*.tar.gz | sed 's/docker\/autoconf-\(.*\)\.tar\.gz/\1/' | head -1`
 BRIDGE_UTILS_VERSION=`ls -r docker/bridge-utils-*.tar.gz | sed 's/docker\/bridge-utils-\(.*\)\.tar\.gz/\1/' | head -1`
-DOCKER_VERSION=`ls -r docker/docker-* | sed 's/docker\/docker-\(.*\)/\1/' | head -1`
+DOCKER_VERSION=`ls -r docker/docker-*.tgz | sed 's/docker\/docker-\(.*\)\.tgz/\1/' | head -1`
 
 # Extract Autoconf package
 echo "Extracting Autoconf ${AUTOCONF_VERSION}..."
@@ -45,8 +45,15 @@ autoconf
 make -j${CPUS}
 make install
 
-# Copy Docker package
-echo "Copying Docker ${DOCKER_VERSION}..."
+# Extract docker package
+echo "Extracting docker ${DOCKER_VERSION}..."
+tar xzvf ${BOSH_COMPILE_TARGET}/docker/docker-${DOCKER_VERSION}.tgz 
+if [[ $? != 0 ]] ; then
+  echo "Failed extracting docker ${DOCKER_VERSION}"
+  exit 1
+fi
+
+echo "Copying docker ${DOCKER_VERSION} binaries..."
 mkdir -p ${BOSH_INSTALL_TARGET}/bin
-cp -a ${BOSH_COMPILE_TARGET}/docker/docker-${DOCKER_VERSION} ${BOSH_INSTALL_TARGET}/bin/docker
-chmod +x ${BOSH_INSTALL_TARGET}/bin/docker
+cp docker/* ${BOSH_INSTALL_TARGET}/bin
+chmod +x ${BOSH_INSTALL_TARGET}/bin/*

--- a/packages/docker/spec
+++ b/packages/docker/spec
@@ -5,4 +5,4 @@ files:
   - docker/aufs-tools_20120411-3_amd64.deb
   - docker/autoconf-2.69.tar.gz
   - docker/bridge-utils-1.5.tar.gz
-  - docker/docker-1.10.2
+  - docker/docker-1.11.0.tgz


### PR DESCRIPTION
Signed-off-by: Satheesh Uppalapati <Satheesh.Uppalapati@allstate.com>

This PR addresses bug #56. To make a release of it we would need to get `docker/docker-1.11.0.tgz` blob sync. 

*Linux 64bit tgz*: https://get.docker.com/builds/Linux/x86_64/docker-1.11.0.tgz