### PR TITLE
Added missing obligatory setting for CF containers broker in accordan…

### DIFF
--- a/jobs/cf-containers-broker/templates/config/settings.yml.erb
+++ b/jobs/cf-containers-broker/templates/config/settings.yml.erb
@@ -25,5 +25,6 @@ production:
   host_directory: /var/vcap/store/cf-containers-broker/
   max_containers: <%= p('broker.max_containers') %>
   allocate_docker_host_ports: <%= p('broker.allocate_docker_host_ports') %>
+  container_env_var_dir: '/var/vcap/store/cf-containers-broker/envdir'
 
   services: <%= JSON.pretty_generate(p('broker.services')) %>


### PR DESCRIPTION
Docker broker does not perform any service operation on v26 like 'create service'.
Complain is about no 'container_env_var_dir' property in /var/vcap/jobs/cf-containers-broker/config/settings.yml.

Looking to src/cf-containers-broker/config it is easy to see that settings.xml contain appropriate setting which is not not a part of /jobs/cf-containers-broker/templates/config/settings.yml.erb.
It looks like this is only needed for some special case because appropriate directory dies not exists. But it helps broker so it performs its work.
