### PR TITLE
Make flannel subnet configurable.

### DIFF
--- a/jobs/flannel/spec
+++ b/jobs/flannel/spec
@@ -12,6 +12,5 @@ properties:
   apiserver.ip:
     description: ip of api server
 
-  kubernetes.master:
-    description: master
-    default: false
+  flannel.ip-range
+    description: ip range of flannel overlay network

--- a/jobs/flannel/templates/bin/ctl
+++ b/jobs/flannel/templates/bin/ctl
@@ -20,12 +20,14 @@ case $1 in
     mkdir -p /dev/net
     mknod /dev/net/tun c 10 200 || true
 
-    <% if properties.kubernetes.master %> \
-    /var/vcap/packages/etcd/etcdctl set /coreos.com/network/config '{"Network":"10.100.0.0/16"}'
+    <% if_p('flannel.ip-range') do |range| %>
+    curl -XPUT http://<%= p('apiserver.ip') %>:4001/v2/keys/coreos.com/network/config \
+      -d value='{"Network": "<%= range %>"}'
     <% end %>
+
     exec /var/vcap/packages/flannel/bin/flanneld \
-         -etcd-endpoints="http://<%= properties.apiserver.ip %>:4001"\
-         >>$LOG_DIR/$JOB_NAME.log 2>&1
+      -etcd-endpoints="http://<%= properties.apiserver.ip %>:4001" \
+      >>$LOG_DIR/$JOB_NAME.log 2>&1
 
     ;;
 


### PR DESCRIPTION
* Expose flannel subnet range as `flannel.ip-range`
* Use `curl` instead of `etcdctl`; etcd may live on separate host

WDYT @lnguyen?