### PR TITLE
Fix typo in spec.

### DIFF
--- a/jobs/flannel/spec
+++ b/jobs/flannel/spec
@@ -12,5 +12,5 @@ properties:
   apiserver.ip:
     description: ip of api server
 
-  flannel.ip-range
+  flannel.ip-range:
     description: ip range of flannel overlay network


### PR DESCRIPTION
Sorry, my yaml linter doesn't check `spec` files! I tried this out and it works as expected.
