### PR TITLE
Add property for --env-file option to docker run.

### DIFF
--- a/CONTAINERS.md
+++ b/CONTAINERS.md
@@ -47,6 +47,7 @@ Containers to be deployed must be specified at the properties section of each jo
 | containers[].dns_options[] | N | Array of Strings | DNS options to add to the container
 | containers[].dns_search[] | N | Array of Strings | DNS search domains to add to the container
 | containers[].entrypoint | N | String | Entrypoint for the container (only if you want to override the default entrypoint set by the image)
+| containers[].env_file | N | Array of Strings | Paths of files containing environment variables to pass to the container
 | containers[].env_vars[] | N | Array of Strings | Environment variables to pass to the container
 | containers[].expose_ports[] | N | Array of Strings | Network ports to expose from the container without publishing it to your host
 | containers[].group_adds[] | N | Array of Strings | Groups to join

--- a/jobs/containers/spec
+++ b/jobs/containers/spec
@@ -28,6 +28,7 @@ properties:
       containers.dns_options: Optional array of strings to set custom DNS servers
       containers.dns_search: Optional array of strings to set custom DNS search domains
       containers.entrypoint: Optional string containing the entrypoint (only if you want to override the default entrypoint set by the image)
+      containers.env_file: Optional paths to files of environment variables to pass to the container
       containers.env_vars: Optional array of environment variables to pass to the container
       containers.expose_ports: Optional array of network port to expose from the container without publishing it to your host
       containers.group_adds: Optional array of additional groups to join

--- a/jobs/containers/templates/bin/containers_ctl.erb
+++ b/jobs/containers/templates/bin/containers_ctl.erb
@@ -50,6 +50,7 @@ case $1 in
       "$(eval echo "\$${container_name}_dns_options")" \
       "$(eval echo "\$${container_name}_dns_search")" \
       "$(eval echo "\$${container_name}_entrypoint")" \
+      "$(eval echo "\$${container_name}_env_file")" \
       "$(eval echo "\$${container_name}_env")" \
       "$(eval echo "\$${container_name}_expose")" \
       "$(eval echo "\$${container_name}_group_adds")" \

--- a/jobs/containers/templates/bin/job_properties.sh.erb
+++ b/jobs/containers/templates/bin/job_properties.sh.erb
@@ -93,6 +93,11 @@ export <%= container['name'] %>_dns_search="<%= Array(container['dns_search']).j
 export <%= container['name'] %>_entrypoint="--entrypoint=<%= container['entrypoint'] %>"
 <% end %>
 
+<% unless container['env_file'].nil? || container['env_file'].empty? %>
+# Set environment variables files
+export <%= container['name'] %>_env="<%= Array(container['env_file']).join(',').split(',').map { |file| "--env-file #{file}" }.join(' ') %>"
+<% end %>
+
 <% unless container['env_vars'].nil? || container['env_vars'].empty? %>
 # Set environment variables
 export <%= container['name'] %>_env="<%= Array(container['env_vars']).join(',').split(',').map { |var| "--env #{var}" }.join(' ') %>"

--- a/jobs/flannel/spec
+++ b/jobs/flannel/spec
@@ -12,5 +12,5 @@ properties:
   apiserver.ip:
     description: ip of api server
 
-  flannel.ip-range
+  flannel.ip-range:
     description: ip range of flannel overlay network


### PR DESCRIPTION
This makes it much simpler to, e.g., pass JSON in through an environment variable, since it avoids multiple layers of shell-escaping that would be needed with --env/env_vars. Here's the [docker run doc for --env-file](https://docs.docker.com/engine/reference/commandline/run/#/set-environment-variables--e---env---env-file).