### PR TITLE
Externalizing the Docker bridge IP as a BOSH property.

### DIFF
--- a/jobs/docker/spec
+++ b/jobs/docker/spec
@@ -69,6 +69,8 @@ properties:
   ip_masq:
     description: "Enable IP masquerading"
     default: true
+  bip:
+    description: "Bridge IP in CIDR form. Example: 172.17.0.1/24. If set, this value will be used for the docker0 bridge '--bip' argument."
   iptables:
     description: "Enable Docker's addition of iptables rules"
     default: true

--- a/jobs/docker/templates/bin/ctl
+++ b/jobs/docker/templates/bin/ctl
@@ -79,7 +79,7 @@ case $1 in
         ${DOCKER_TLS_CERT} \
         ${DOCKER_TLS_KEY} \
         ${DOCKER_USERLAND_PROXY} \
-        ${DOCKER_FLANNEL:-} \
+        ${DOCKER_BIP:-} \
         >>${DOCKER_LOG_DIR}/${OUTPUT_LABEL}.stdout.log \
         2>>${DOCKER_LOG_DIR}/${OUTPUT_LABEL}.stderr.log
     ;;

--- a/jobs/docker/templates/bin/job_properties.sh.erb
+++ b/jobs/docker/templates/bin/job_properties.sh.erb
@@ -158,7 +158,12 @@ export DOCKER_ULIMIT_NOFILE=<%= p('ulimit.nofile') -%>
 
 <% if p('flannel', false) -%>
 source /run/flannel/subnet.env
-export DOCKER_FLANNEL="--bip=${FLANNEL_SUBNET} --mtu=${FLANNEL_MTU}"
+export DOCKER_BIP="--bip=${FLANNEL_SUBNET}"
+export DOCKER_MTU="--mtu=${FLANNEL_MTU}"
+<% end -%>
+
+<% if_p('bip') do |bip| -%>
+export DOCKER_BIP="--bip=<%= bip %>"
 <% end -%>
 
 # Proxy configuration


### PR DESCRIPTION
Allowing an operator to explicitly set the bridge IP, which is
passed to the docker daemon via the '--bip' flag, is useful when
the IP of the docker0 NIC needs to be customized.

Example: when deploying Kubernetes with CNI, and a Flannel overlay, the
docker0 NIC (and associated route) must not conflict with CNI.

Signed-off-by: Josh Winters <jwinters@pivotal.io>