### PR TITLE
bosh run-errand does not cleanup jobs, so avoid persistent disk

### DIFF
--- a/jobs/docker/templates/bin/ctl
+++ b/jobs/docker/templates/bin/ctl
@@ -2,6 +2,12 @@
 
 set -e # exit immediately if a simple command exits with a non-zero status
 
+if [[ -z $(df | grep /var/vcap/store) ]]; then
+  echo "WARNING: No persisent disk provided. Setting up symlink to ephemeral disk."
+  mkdir -p /var/vcap/data/weak-store
+  ln -s /var/vcap/data/weak-store /var/vcap/store
+fi
+
 # Setup common env vars and folders
 source /var/vcap/packages/bosh-helpers/ctl_setup.sh 'docker'
 export DOCKER_PID_FILE=${DOCKER_PID_DIR}/docker.pid

--- a/manifests/broker/docker-broker.yml
+++ b/manifests/broker/docker-broker.yml
@@ -57,7 +57,6 @@ instance_groups:
   azs: [z1]
   lifecycle: errand
   instances: 1
-  persistent_disk: 65536
   vm_type: default
   stemcell: default
   networks: [{name: default}]


### PR DESCRIPTION
Workaround for https://github.com/cloudfoundry/bosh/issues/1755