### PR TITLE
Fix dns options for containers job

### DIFF
--- a/jobs/containers/spec
+++ b/jobs/containers/spec
@@ -15,12 +15,12 @@ properties:
       containers.name: String containing the name of the container
       containers.image: String containing the name of the image to create/run
       containers.command: Optional String containing the command to the run (including arguments)
-      containers.blkio_weight: Optional string containg the Block IO (relative weight)
+      containers.blkio_weight: Optional string containing the Block IO (relative weight)
       containers.cap_adds: Optional array of Linux capabilities to add
       containers.cap_drops: Optional array of Linux capabilities to drop
-      containers.cpu_period: Optional string containg the CPU CFS (Completely Fair Scheduler) period limit
-      containers.cpu_quota: Optional string containg the CPU CFS (Completely Fair Scheduler) quota limit
-      containers.cpu_shares: Optional string containg the CPU shares to assign to the container (relative weight)
+      containers.cpu_period: Optional string containing the CPU CFS (Completely Fair Scheduler) period limit
+      containers.cpu_quota: Optional string containing the CPU CFS (Completely Fair Scheduler) quota limit
+      containers.cpu_shares: Optional string containing the CPU shares to assign to the container (relative weight)
       containers.depends_on: Optional array of names of others containers in the same job that this container depends on
       containers.devices: Optional array of host devices to add to the container
       containers.disable_content_trust: Optional boolean to skip image verification

--- a/jobs/containers/templates/bin/job_properties.sh.erb
+++ b/jobs/containers/templates/bin/job_properties.sh.erb
@@ -74,17 +74,17 @@ export <%= container['name'] %>_devices="<%= Array(container['devices']).join(',
 export <%= container['name'] %>_disable_content_trust="--disable-content-trust=<%= container.has_key?('disable_content_trust') ? container['disable_content_trust'] : true %>"
 
 <% unless container['dns'].nil? || container['dns'].empty? %>
-Set custom DNS servers
+# Set custom DNS servers
 export <%= container['name'] %>_dns="<%= Array(container['dns']).join(',').split(',').map { |server| "--dns=#{server}" }.join(' ') %>"
 <% end %>
 
 <% unless container['dns_options'].nil? || container['dns_options'].empty? %>
-Set DNS options
+# Set DNS options
 export <%= container['name'] %>_dns_options="<%= Array(container['dns_options']).join(',').split(',').map { |option| "--dns-opt=#{option}" }.join(' ') %>"
 <% end %>
 
 <% unless container['dns_search'].nil? || container['dns_search'].empty? %>
-Set custom DNS search domains
+# Set custom DNS search domains
 export <%= container['name'] %>_dns_search="<%= Array(container['dns_search']).join(',').split(',').map { |domain| "--dns-search=#{domain}" }.join(' ') %>"
 <% end %>
 
@@ -169,7 +169,7 @@ export <%= container['name'] %>_memory_swap="--memory-swap=<%= container['memory
 <% end %>
 
 <% if container['memory_swappiness'] %>
-Tuning container memory swappiness
+# Tuning container memory swappiness
 export <%= container['name'] %>_memory_swappiness="--memory-swappiness=<%= container['memory_swappiness'] %>"
 <% end %>
 


### PR DESCRIPTION
When specifying one these options the release breaks:
* dns
* dns_options
* dns_search

This PR fixes the comment headers in the job properties as well as few spelling mistakes in the job spec.