### PR TITLE
Put docker storage under /var/vcap/data.

### DIFF
--- a/jobs/docker/templates/bin/ctl
+++ b/jobs/docker/templates/bin/ctl
@@ -6,6 +6,8 @@ set -e # exit immediately if a simple command exits with a non-zero status
 source /var/vcap/packages/bosh-helpers/ctl_setup.sh 'docker'
 export DOCKER_PID_FILE=${DOCKER_PID_DIR}/docker.pid
 export PATH="/var/vcap/packages/docker/bin:$PATH"
+export TMPDIR="/var/vcap/data/tmp"
+export DOCKER_STORE_DIR="/var/vcap/data"
 
 case $1 in
 


### PR DESCRIPTION
Without this, large docker images fail to load.

We had a case where we tried to load a large docker image tarball into docker-boshrelease's docker daemon, and it ran out of disk space. The `/var/vcap/data` disk seems to be the only large (and configurable) disk. This change sets the temporary directory (used to un-tar the docker image) and the docker storage directory (used to unpack the in-container disks) to paths under `/var/vcap/data`.