### PR TITLE
Allow config of vm.max_map_count

### DIFF
--- a/jobs/docker/spec
+++ b/jobs/docker/spec
@@ -112,6 +112,10 @@ properties:
     description: "Maximum number of open files"
     default: 8192
 
+  vm.max_map_count:
+    description: "If set, sets vm.max_map_count on VM"
+    default: ""
+
   flannel:
     description: "Enable flannel support"
     default: false

--- a/jobs/docker/templates/bin/ctl
+++ b/jobs/docker/templates/bin/ctl
@@ -24,6 +24,9 @@ case $1 in
     # Set ulimits
     ulimit -n ${DOCKER_ULIMIT_NOFILE}
 
+    # Set vm.max_map_count
+    [ -n "${DOCKER_VM_MAX_MAP_COUNT}" ] && sysctl -w vm.max_map_count=${DOCKER_VM_MAX_MAP_COUNT}
+
     # Mount cgroupfs hierarchy
     ${JOB_DIR}/bin/cgroupfs-mount
 

--- a/jobs/docker/templates/bin/job_properties.sh.erb
+++ b/jobs/docker/templates/bin/job_properties.sh.erb
@@ -156,6 +156,9 @@ export DOCKER_USERLAND_PROXY="--userland-proxy=<%= p('userland_proxy') %>"
 # Maximum number of open files
 export DOCKER_ULIMIT_NOFILE=<%= p('ulimit.nofile') %>
 
+# mmap counts
+export DOCKER_VM_MAX_MAP_COUNT=<%= p('vm.max_map_count') %>
+
 <% if p('flannel', false) %>
 source /run/flannel/subnet.env
 export DOCKER_BIP="--bip=${FLANNEL_SUBNET}"


### PR DESCRIPTION
Some images (such as ElasticSearch) require `vm.max_map_count` to be set higher than normal defaults.

(not sure if this is the best way to do this, but it seemed to work for us)