### PR TITLE
Allow disable remote docker access (and requirement for TLS certs)

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,9 @@
+* only require tls certs if `docker.tcp_address` is not `127.0.0.1` (the current default) [see [conversation](https://github.com/cloudfoundry-community/docker-boshrelease/commit/0f8c49204f926cd300ac7c59c305dfbf4e2eb324#commitcomment-25484535)]
+
+    Added operator file to disable external docker access and the need for TLS certs:
+
+    ```
+    bosh deploy manifests/containers/example.yml -o manifests/op-disable-remote-docker-access.yml
+    ```
+
+* fix bug in `containers` job's `job_properties.sh.erb` templates

--- a/jobs/docker/spec
+++ b/jobs/docker/spec
@@ -32,6 +32,14 @@ properties:
   tcp_port:
     description: "TCP port where Docker daemon will listen to (if not set, TCP will not be available)"
     default: "4243"
+
+  tls_cacert:
+    description: "Trust only remotes providing a certificate signed by the CA given here, if tcp_address not 127.0.0.1"
+  tls_cert:
+    description: "TLS certificate file, if tcp_address not 127.0.0.1"
+  tls_key:
+    description: "TLS key file, if tcp_address not 127.0.0.1"
+
   bridge:
     description: "Name of the network bridge to attach containers (defaults to docker0)"
   cidr_prefix:
@@ -97,13 +105,6 @@ properties:
     description: "Use a specific storage driver"
   storage_options:
     description: "Array of storage driver options"
-
-  tls_cacert:
-    description: "Trust only remotes providing a certificate signed by the CA given here"
-  tls_cert:
-    description: "TLS certificate file"
-  tls_key:
-    description: "TLS key file"
 
   userland_proxy:
     description: "Use userland proxy for loopback traffic"

--- a/jobs/docker/templates/bin/job_properties.sh.erb
+++ b/jobs/docker/templates/bin/job_properties.sh.erb
@@ -23,6 +23,20 @@ export DOCKER_TMP_DIR=${TMP_DIR}
 <% if_p('tcp_address', 'tcp_port') do |address, port| %>
 # TCP Address/Port where Docker daemon will listen to
 export DOCKER_TCP="--host tcp://<%= address %>:<%= port %>"
+
+<% unless address == "127.0.0.1" || address == "localhost" %>
+# Use TLS and verify the remote
+export DOCKER_TLS_VERIFY_OPTION="--tlsverify=true"
+
+# Trust only remotes providing a certificate signed by the CA given here
+export DOCKER_TLS_CACERT="--tlscacert=${DOCKER_CONF_DIR}/docker.cacert"
+
+# Path to TLS certificate file
+export DOCKER_TLS_CERT="--tlscert=${DOCKER_CONF_DIR}/docker.cert"
+
+# Path to TLS key file
+export DOCKER_TLS_KEY="--tlskey=${DOCKER_CONF_DIR}/docker.key"
+<% end %>
 <% end %>
 
 <% if_p('bridge', 'cidr_prefix') do |bridge, cidr_prefix| %>
@@ -138,18 +152,6 @@ export DOCKER_STORAGE_DRIVER="--storage-driver=<%= storage_driver %>"
 # Storage driver options
 export DOCKER_STORAGE_OPTIONS="<%= storage_options.map { |storage_option| "--storage-opt=#{storage_option}" }.join(' ') %>"
 <% end %>
-
-# Use TLS and verify the remote
-export DOCKER_TLS_VERIFY_OPTION="--tlsverify=true"
-
-# Trust only remotes providing a certificate signed by the CA given here
-export DOCKER_TLS_CACERT="--tlscacert=${DOCKER_CONF_DIR}/docker.cacert"
-
-# Path to TLS certificate file
-export DOCKER_TLS_CERT="--tlscert=${DOCKER_CONF_DIR}/docker.cert"
-
-# Path to TLS key file
-export DOCKER_TLS_KEY="--tlskey=${DOCKER_CONF_DIR}/docker.key"
 
 # Use userland proxy for loopback traffic
 export DOCKER_USERLAND_PROXY="--userland-proxy=<%= p('userland_proxy') %>"

--- a/jobs/docker/templates/config/docker.cacert.erb
+++ b/jobs/docker/templates/config/docker.cacert.erb
@@ -1,8 +1,12 @@
 <%=
+unless p('tcp_address') == "127.0.0.1" || p('tcp_address') == "localhost"
   cert = p('tls_cacert')
   if cert.index("\n").nil?
     cert.gsub('\\n', "\n")
   else
     cert
   end
+else
+  ""
+end
 %>

--- a/jobs/docker/templates/config/docker.cert.erb
+++ b/jobs/docker/templates/config/docker.cert.erb
@@ -1,8 +1,12 @@
 <%=
+unless p('tcp_address') == "127.0.0.1" || p('tcp_address') == "localhost"
   cert = p('tls_cert')
   if cert.index("\n").nil?
     cert.gsub('\\n', "\n")
   else
     cert
   end
+else
+  ""
+end
 %>

--- a/jobs/docker/templates/config/docker.key.erb
+++ b/jobs/docker/templates/config/docker.key.erb
@@ -1,8 +1,12 @@
 <%=
+unless p('tcp_address') == "127.0.0.1" || p('tcp_address') == "localhost"
   cert = p('tls_key')
   if cert.index("\n").nil?
     cert.gsub('\\n', "\n")
   else
     cert
   end
+else
+  ""
+end
 %>

--- a/manifests/op-disable-remote-docker-access.yml
+++ b/manifests/op-disable-remote-docker-access.yml
@@ -1,0 +1,12 @@
+- type: replace
+  path: /instance_groups/name=docker/jobs/name=docker/properties/tcp_address
+  value: 127.0.0.1
+
+- type: remove
+  path: /instance_groups/name=docker/jobs/name=docker/properties/tls_cacert
+
+- type: remove
+  path: /instance_groups/name=docker/jobs/name=docker/properties/tls_cert
+
+- type: remove
+  path: /instance_groups/name=docker/jobs/name=docker/properties/tls_key


### PR DESCRIPTION
@damaru-inc look good for you? Just set `docker.tcp_address` to 127.0.0.1 (the default) and TLS certs won't be required.

See https://github.com/cloudfoundry-community/docker-boshrelease/commit/0f8c49204f926cd300ac7c59c305dfbf4e2eb324#commitcomment-25484535