### PR TITLE
Allow customizing Monit timeout length

### DIFF
--- a/jobs/containers/monit
+++ b/jobs/containers/monit
@@ -1,7 +1,7 @@
 <% p('containers', []).each do |container| %>
 check process <%= container['name'] %> with pidfile /var/vcap/sys/run/containers/<%= container['name'] %>.pid
   group vcap
-  start program "/var/vcap/packages/bosh-helpers/monit_debugger <%= container['name'] %>_ctl '/var/vcap/jobs/containers/bin/ctl start <%= container['name'] %>'"
+  start program "/var/vcap/packages/bosh-helpers/monit_debugger <%= container['name'] %>_ctl '/var/vcap/jobs/containers/bin/ctl start <%= container['name'] %>'" <% unless container['timeout'].to_s.empty? %>with timeout <%= container['timeout'] %> seconds<% end %>
   stop program "/var/vcap/packages/bosh-helpers/monit_debugger <%= container['name'] %>_ctl '/var/vcap/jobs/containers/bin/ctl stop <%= container['name'] %>'"
   depends on <%= ['docker'].concat(Array(container.fetch('depends_on', []))).join(',') %>
 <% end %>

--- a/jobs/containers/spec
+++ b/jobs/containers/spec
@@ -52,6 +52,7 @@ properties:
       containers.restart: Optional string containing the restart policy to apply when a container exits (no, on-failure, always)
       containers.security_options: Optional array of security options
       containers.stop_signal: Optional string containing the signal to stop a container, SIGTERM by default
+      containers.timeout: Optional string containing the length of Monit timeout in seconds
       containers.ulimits: Optional array of Ulimit options
       containers.user: Optional string containing the username or UID to run the first process
       containers.volumes: Optional array of volumes to bind mount


### PR DESCRIPTION
The default Monit timeout is 30s, and since some images may depend on others, this timeout may not be enough. 